### PR TITLE
Show more info at experiment sizing calc

### DIFF
--- a/mojito-functions/experiment_sizing.R
+++ b/mojito-functions/experiment_sizing.R
@@ -56,6 +56,7 @@ estimateDurationQuery <- function(app_id, trigger_clause, conversion_clause, sub
   estimateData$target_cvr <- estimateData$base_cvr*(1+delta)
   days_to_run <- durationEstimation(users=estimateData$subjects, conversions=estimateData$conversions, delta, recipes, stat_power)
   print(paste("Days to run:", days_to_run))
+  print(estimateData)
 
   # Return a list with the estimate results
   estimateData$days_to_run <- days_to_run


### PR DESCRIPTION
This just adds some more context to the output, like the subjects, conversions and conversion rates:

```
> wave_eta <- estimateDurationQuery(
+   app_id = "xxx",
+   trigger_clause = "page_urlpath like '/support/%'",
+   conversion_clause = "page_urlpath = '/contact-us/'", # 
+   delta = -0.10,
+   recipes = 2,
+   stat_power = 0.8
+ )
[1] "Days to run: 46.6992309052861"
  subjects conversions   base_cvr target_cvr
1    29901        1806 0.06039932 0.05435939
```

