### PR TITLE
Experiment sizing: Fix list returned by raw estimate when no app_id/subject definition

### DIFF
--- a/mojito-functions/experiment_sizing.R
+++ b/mojito-functions/experiment_sizing.R
@@ -87,8 +87,6 @@ estimateDurationRaw <- function(subjects, conversions, delta, recipes, stat_powe
   # Return a list with the estimate results
   estimateData$days_to_run <- days_to_run
   eta_list <- list(
-      "app_id" = app_id,
-      "subject" = subject,
       "delta" = delta,
       "recipes" = recipes,
       "stat_power" = stat_power,


### PR DESCRIPTION
These were never needed for raw sizing. Quick fix to remove app_id/subject from the list returned.