### PR TITLE
Switch our recommended knitr template & update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ Fully templateable experiment reports for Mojito Snowplow/Redshift, using R Mark
 
 ![Mojito report](reports.png)
 
-**NB:** Use restricted users with read-only access. We assume your analysts are good actors with their SQL logins and won't do anything dodgy.
-
 ## Features
 
  - Measure tests against a series of configurable metrics
  - Measure changes in time to convert
  - Goal counts / conversion depth reports for measuring frequency / user loyalty (e.g. user transacted 2 or more times)
- - Diagnostic functions check for [assignment problems (SRM test)](https://twitter.com/ronnyk/status/932798952679776256?lang=en) and [experiment errors](https://mintmetrics.io/experiments/why-you-need-error-tracking-handling-in-your-split-tests/)
+ - Diagnostic functions check for [assignment problems (SRM test)](https://www.lukasvermeer.nl/srm/) and [experiment errors](https://mintmetrics.io/experiments/why-you-need-error-tracking-handling-in-your-split-tests/)
+
+## Links
+
+- [Full documentation](https://mojito.mx/docs/r-analytics-intro)
+- [Open an issue on Github](https://github.com/mint-metrics/mojito-r-analytics/issues/new)
+
 
 ## Prerequisites
 
@@ -128,8 +132,8 @@ We're keen to help you get set up - Open issues with any problems you encounter.
 
 Eventually we'd love to add Bayesian inferential stats to our reports - we're currently playing with it, but not fully comfortable with it yet for production reports.
 
+Learn more & get in touch:
 
-Reach out via:
-
+* [Full documentation](https://mojito.mx/docs/r-analytics-intro)
 * [Open an issue on Github](https://github.com/mint-metrics/mojito-r-analytics/issues/new)
-* [Mint Metrics' website](https://mintmetrics.io/)
+* [Contact Mint Metrics](https://mintmetrics.io/)

--- a/wave_report.Rmd
+++ b/wave_report.Rmd
@@ -2,15 +2,15 @@
 title: 'EX1 Experiment for Google users'
 author: 'Mint Metrics'
 date: Knitted `r format(Sys.Date(),format = "%d %B %Y")`
-header-includes:
 output:
-  prettydoc::html_pretty:
-    theme: cayman
-    highlight: github
-mainfont: Roboto Light
+  html_document:
+    toc: true
+    toc_float: true
+    theme: sandstone
 ---
+<style type="text/css">@media print {#TOC {display: none;}}</style>
 ```{r includes, include=FALSE, echo=FALSE, cache=FALSE, warning=FALSE}
-# Optional: Path to Redshift/PostgreSQL connection (must expose "con" connection variable in this namespace)
+# TO CONFIGURE: Path to Redshift/PostgreSQL connection (must expose "con" connection variable in this namespace)
 for (lib in c("reports","plots","tables","queries_snowplow_redshift","experiment_sizing")) {
   source(paste0("./mojito-functions/",lib,".R"))
 }
@@ -27,17 +27,11 @@ wave_params <- list(
 )
 ```
 
-## Details
-
-**Hypotheses:  ** The treatment will increase transactions.
-
 **Started:     ** `r wave_params$start_date`
 
 **Ended:       ** `r mojitoReportDates(wave_params)`
 
-## Summary
-
- * TBA
+# Summary
 
 ```{r, echo=FALSE, message=FALSE, warning=FALSE, results='asis', fig.height=3, fig.width=10, fig.align='center'}
 goalList <- list(


### PR DESCRIPTION
This switches to the new knitr template we're using (sandstone): https://www.datadreaming.org/post/r-markdown-theme-gallery/#sandstone-theme

![Screen Shot 2020-06-11 at 17 06 26](https://user-images.githubusercontent.com/2361388/84355740-77540e00-ac06-11ea-8acf-e04ae8cf26b9.png)

Also makes a few updates to the readme, like linking to our docs and to a better SRM resource at last.